### PR TITLE
Update to 2.6.0

### DIFF
--- a/org.jitsi.jitsi-meet.metainfo.xml
+++ b/org.jitsi.jitsi-meet.metainfo.xml
@@ -30,6 +30,7 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release version="2.6.0" date="2021-03-04"/>
         <release version="2.5.1" date="2021-02-23"/>
         <release version="2.4.2" date="2020-10-29"/>
         <release version="2.4.1" date="2020-10-02"/>

--- a/org.jitsi.jitsi-meet.yaml
+++ b/org.jitsi.jitsi-meet.yaml
@@ -57,6 +57,6 @@ modules:
         path: org.jitsi.jitsi-meet.jitsi-meet.xml
       - type: file
         filename: jitsi-meet-x86_64.AppImage
-        url: https://github.com/jitsi/jitsi-meet-electron/releases/download/v2.5.1/jitsi-meet-x86_64.AppImage
-        sha256: c2a38a7a8b70565dbcb798d4c1a16d07b487f48862eb490e03244c67d369ba4c
-        size: 88657548
+        url: https://github.com/jitsi/jitsi-meet-electron/releases/download/v2.6.0/jitsi-meet-x86_64.AppImage
+        sha256: 1116c99eaae3cfb8238690d64c028ef09eb5bdab703cc24cf1249e233f0a04ae
+        size: 91956978


### PR DESCRIPTION
Electron 12, reenabled GPU acceleration and smaller fixes: https://github.com/jitsi/jitsi-meet-electron/releases/tag/v2.6.0