### PR TITLE
Update to 2.6.1

### DIFF
--- a/org.jitsi.jitsi-meet.metainfo.xml
+++ b/org.jitsi.jitsi-meet.metainfo.xml
@@ -30,6 +30,7 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release version="2.6.1" date="2021-03-05"/>
         <release version="2.6.0" date="2021-03-04"/>
         <release version="2.5.1" date="2021-02-23"/>
         <release version="2.4.2" date="2020-10-29"/>

--- a/org.jitsi.jitsi-meet.yaml
+++ b/org.jitsi.jitsi-meet.yaml
@@ -57,6 +57,6 @@ modules:
         path: org.jitsi.jitsi-meet.jitsi-meet.xml
       - type: file
         filename: jitsi-meet-x86_64.AppImage
-        url: https://github.com/jitsi/jitsi-meet-electron/releases/download/v2.6.0/jitsi-meet-x86_64.AppImage
-        sha256: 1116c99eaae3cfb8238690d64c028ef09eb5bdab703cc24cf1249e233f0a04ae
-        size: 91956978
+        url: https://github.com/jitsi/jitsi-meet-electron/releases/download/v2.6.1/jitsi-meet-x86_64.AppImage
+        sha256: 9bced135f06204dd6cac890a46b2cf8c09f915e17dbbab3dec818477fd564a9b
+        size: 91957773


### PR DESCRIPTION
Prevent AoT and SS-tracker windows from being captured: https://github.com/jitsi/jitsi-meet-electron/releases/tag/v2.6.1