### PR TITLE
Update to 2.7.0

### DIFF
--- a/org.jitsi.jitsi-meet.metainfo.xml
+++ b/org.jitsi.jitsi-meet.metainfo.xml
@@ -30,6 +30,7 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release version="2.7.0" date="2021-03-10"/>
         <release version="2.6.1" date="2021-03-05"/>
         <release version="2.6.0" date="2021-03-04"/>
         <release version="2.5.1" date="2021-02-23"/>

--- a/org.jitsi.jitsi-meet.yaml
+++ b/org.jitsi.jitsi-meet.yaml
@@ -57,6 +57,6 @@ modules:
         path: org.jitsi.jitsi-meet.jitsi-meet.xml
       - type: file
         filename: jitsi-meet-x86_64.AppImage
-        url: https://github.com/jitsi/jitsi-meet-electron/releases/download/v2.6.1/jitsi-meet-x86_64.AppImage
-        sha256: 9bced135f06204dd6cac890a46b2cf8c09f915e17dbbab3dec818477fd564a9b
-        size: 91957773
+        url: https://github.com/jitsi/jitsi-meet-electron/releases/download/v2.7.0/jitsi-meet-x86_64.AppImage
+        sha256: f624b8d841dee1ec7bb4d3cb2e6a84e96c102b21e58700c9be4d67ab88561cbd
+        size: 91961304


### PR DESCRIPTION
https://github.com/jitsi/jitsi-meet-electron/releases/tag/v2.7.0: Bump elliptic from 6.5.3 to 6.5.4