### PR TITLE
Update to 2.8.3

### DIFF
--- a/org.jitsi.jitsi-meet.metainfo.xml
+++ b/org.jitsi.jitsi-meet.metainfo.xml
@@ -30,6 +30,7 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release version="2.8.3" date="2021-03-24"/>
         <release version="2.7.1" date="2021-03-12"/>
         <release version="2.7.0" date="2021-03-10"/>
         <release version="2.6.1" date="2021-03-05"/>

--- a/org.jitsi.jitsi-meet.yaml
+++ b/org.jitsi.jitsi-meet.yaml
@@ -57,6 +57,6 @@ modules:
         path: org.jitsi.jitsi-meet.jitsi-meet.xml
       - type: file
         filename: jitsi-meet-x86_64.AppImage
-        url: https://github.com/jitsi/jitsi-meet-electron/releases/download/v2.7.1/jitsi-meet-x86_64.AppImage
-        sha256: 042a67d1cd08cceb1bebc3ec82eeb6ca8f4f33078fc0e62dc5cfadccc7f3cc2f
-        size: 91967014
+        url: https://github.com/jitsi/jitsi-meet-electron/releases/download/v2.8.3/jitsi-meet-x86_64.AppImage
+        sha256: 290972ba20d0ef57e679cce5fc5137f16586804df88a4cb3a1b6abae3907e430
+        size: 91900738


### PR DESCRIPTION
Update Electron to 12.0.2, support for mailto links: https://github.com/jitsi/jitsi-meet-electron/releases/tag/v2.8.3