### PR TITLE
Remove unused pipewire 0.2

### DIFF
--- a/org.jitsi.jitsi-meet.yaml
+++ b/org.jitsi.jitsi-meet.yaml
@@ -34,22 +34,6 @@ modules:
         url: https://github.com/refi64/unappimage
         commit: d7f86f2a0d7ec3a69211125207d5f127386b849a
 
-  - name: pipewire
-    buildsystem: meson
-    config-opts:
-      - -Dgstreamer=disabled
-      - -Dman=false
-      - -Dsystemd=false
-    cleanup:
-      - /include
-      - /bin
-      - /etc
-      - /lib/pkgconfig
-    sources:
-      - type: git
-        url: https://github.com/PipeWire/pipewire.git
-        tag: 0.2.7
-
   - name: jitsi-meet
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
jitsi-meet-electron 2.8.9 also moved to PipeWire 0.3 as electron was
updated from 12 to 13.