### PR TITLE
Add option for enabling Wayland support by environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,19 @@ Jitsi Meet
 ----------
 
 Flatpak wrapper around the official Jitsi Meet desktop application - https://github.com/jitsi/jitsi-meet-electron
+
+## Wayland support
+
+Jitsi Meet's Wayland support is currently experimental, and some features like screensharing are broken.
+
+Wayland support can be enabled by setting the environment variable `JITSI_USE_WAYLAND=1` either using [Flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal), or the command line, like so:
+
+```
+$ flatpak override --user --env=JITSI_USE_WAYLAND=1 org.jitsi.jitsi-meet
+```
+
+Wayland support can also be temporarily enabled for a single run::
+
+```
+$ flatpak run --env=JITSI_USE_WAYLAND=1 org.jitsi.jitsi-meet
+```

--- a/jitsi-meet-run
+++ b/jitsi-meet-run
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+EXTRA_ARGS=()
+
+declare -i JITSI_USE_WAYLAND="${JITSI_USE_WAYLAND:-0}"
+
+# Additional args for enabling Wayland
+if [[ "${JITSI_USE_WAYLAND}" -eq 1 && "${XDG_SESSION_TYPE}" == "wayland" ]]; then
+    echo "JITSI_USE_WAYLAND set, adding --ozone-platform=wayland to launch options"
+    EXTRA_ARGS+=(
+        "--ozone-platform=wayland"
+    )
+fi
+
+export TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}"
+exec zypak-wrapper /app/bin/jitsi-meet/jitsi-meet "${EXTRA_ARGS[@]}" "$@"

--- a/org.jitsi.jitsi-meet.yaml
+++ b/org.jitsi.jitsi-meet.yaml
@@ -23,6 +23,9 @@ finish-args:
     # Also used for inhibit
   - --talk-name=org.freedesktop.login1
 
+    # Add option to enable Wayland backend
+  - --env=JITSI_USE_WAYLAND=0
+
 modules:
   - name: jitsi-meet
     buildsystem: simple
@@ -44,10 +47,8 @@ modules:
 
       - mv squashfs-root /app/bin/jitsi-meet
     sources:
-      - type: script
-        dest-filename: jitsi-meet-run
-        commands:
-          - zypak-wrapper /app/bin/jitsi-meet/jitsi-meet "$@"
+      - type: file
+        path: jitsi-meet-run
       - type: file
         path: org.jitsi.jitsi-meet.metainfo.xml
       - type: file


### PR DESCRIPTION
With Wayland seeing increasing adoption, fixing Wayland-specific bugs will become more important. This change will allow users to more easily experiment with Wayland.