### PR TITLE
Add XCURSOR_PATH for setting the cursor under Wayland

### DIFF
--- a/org.jitsi.jitsi-meet.yaml
+++ b/org.jitsi.jitsi-meet.yaml
@@ -25,6 +25,7 @@ finish-args:
 
     # Add option to enable Wayland backend
   - --env=JITSI_USE_WAYLAND=0
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons:~/.icons
 
 modules:
   - name: jitsi-meet


### PR DESCRIPTION
Setting `XCURSOR_PATH` is a fairly common pattern for Electron apps running under Wayland:

https://github.com/flathub/md.obsidian.Obsidian/pull/155