### PR TITLE
WaylandWindowDecorations are default on, remove from wrapper

### DIFF
--- a/jitsi-meet-run
+++ b/jitsi-meet-run
@@ -11,7 +11,6 @@ if [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-"wayland-0"}" ]]; then
     echo "Debug: Enabling Wayland backend"
     EXTRA_ARGS+=(
         --ozone-platform-hint=auto
-	--enable-features=WaylandWindowDecorations
     )
     if [[ -c /dev/nvidia0 ]]; then
         echo "Debug: Detecting Nvidia GPU. disabling GPU sandbox."


### PR DESCRIPTION
Since https://github.com/electron/electron/pull/39582 WaylandWindowDecorations
are on by default, thus no longer the need to set this in the wrapper.

This was part of electron 28 and was backported to electron 27 and 26,
thus we can safely remove it from here as well.
