### PR TITLE
wayland: Now enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,10 @@ Flatpak wrapper around the official Jitsi Meet desktop application - https://git
 
 ## Wayland support
 
-Some of Jitsi Meet's features like screensharing aren't guaranteed to work under Wayland.
+Screensharing works under Wayland, and uses the OS chooser instead of the Jitsi internal one.
 
 Wayland support can be disabled by setting `--nosocket=wayland` either using [Flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal), or the command line, like so:
 
 ```
 $ flatpak override --user --nosocket=wayland org.jitsi.jitsi-meet
-```
-
-Wayland support can also be temporarily enabled for a single run:
-
-```
-$ flatpak run --nosocket=wayland org.jitsi.jitsi-meet
 ```

--- a/jitsi-meet-run
+++ b/jitsi-meet-run
@@ -5,13 +5,7 @@ set -euo pipefail
 EXTRA_ARGS=()
 
 # Borrowed from: https://github.com/flathub/md.obsidian.Obsidian/blob/5312e50f13f48efccd60a90f282b92b38bcec9a1/obsidian.sh#L20
-# Wayland support can be optionally enabled like so:
-# flatpak override --user --socket=wayland org.jitsi.org.jitsi.jitsi-meet
 if [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-"wayland-0"}" ]]; then
-    echo "Debug: Enabling Wayland backend"
-    EXTRA_ARGS+=(
-        --ozone-platform-hint=auto
-    )
     if [[ -c /dev/nvidia0 ]]; then
         echo "Debug: Detecting Nvidia GPU. disabling GPU sandbox."
         EXTRA_ARGS+=(


### PR DESCRIPTION
Since Electron 38 it uses wayland by default if running under wayland.
See https://www.electronjs.org/blog/electron-38-0#removed-electron_ozone_platform_hint-environment-variable

And https://www.electronjs.org/blog/tech-talk-wayland
